### PR TITLE
fix reference to "piano" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ var parts = MidiConvert.parseParts(midiBlob);
 Which can then be used in Tone.Part
 
 ```javascript
-var pianoPart = new Tone.Part(callback, parts.piano).start();
+var pianoPart = new Tone.Part(callback, parts[0]).start();
 ```
 
 The options object encodes how the MIDI file is parsed:


### PR DESCRIPTION
I think this is what the docs should actually say (although referencing parts via name like this would be neat)
