### PR TITLE
added track.id

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The data parsed from the midi file looks like this:
   // an array of midi tracks
   tracks: [
     {
+      id: Number,                     // the position of this track in the array
       name: String,                   // the track name if one was given
       notes: [
         {

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ The data parsed from the midi file looks like this:
     PPQ: Number                       // the Pulses Per Quarter of the midi file
   },
 
+  startTime: Number,                  // the time before the first note plays
+  duration: Number,                   // the time until the last note finishes
+
   // an array of midi tracks
   tracks: [
     {
@@ -38,9 +41,12 @@ The data parsed from the midi file looks like this:
           time: Number,               // time in seconds
           note: String,               // note name, e.g. "C4"
           velocity: Number,           // normalized 0-1 velocity
-          duration: String,           // duration between noteOn and noteOff
+          duration: Number,           // duration between noteOn and noteOff
         }
       ],
+
+      startTime: Number,              // the time before the first note plays
+      duration: Number,               // the time until the last note finishes
 
       // midi control changes
       controlChanges: {

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ MidiConvert makes it straightforward to work with MIDI files in Javascript. It u
 
 
 ```javascript
-//load a midi file
-MidiConvert.load("path/to/midi.mid", function(midi){
-	console.log(midi)
+// load a midi file
+MidiConvert.load("path/to/midi.mid", function(midi) {
+  console.log(midi)
 })
 ```
 
@@ -21,43 +21,47 @@ The data parsed from the midi file looks like this:
 
 ```javascript
 {
-	// the transport and timing data
-	header : {
-		bpm : Number,                     // the tempo, e.g. 120
-		timeSignature : [Number, Number], // the time signature, e.g. [4, 4],
-		PPQ : Number                  	  // the Pulses Per Quarter of the midi file
-	},
-	// an array of midi tracks
-	tracks : [
-		{
-			name : String, // the track name if one was given
-			notes : [
-				{
-					midi : Number, // midi number, e.g. 60
-					time : Number, // time in seconds
-					note : String, // note name, e.g. "C4"
-					velocity : Number,  // normalized 0-1 velocity
-					duration : String   // duration between noteOn and noteOff
-				}
-			],
-			//midi control changes
-			controlChanges : {
-				//if there are control changes in the midi file
-				'91' : [
-					{
-						number : Number // the cc number
-						time : Number, // time in seconds
-						value : Number  // normalized 0-1
-					}
-				],
-			},
-      instrument : String         // the instrument if one is given
-      instrumentPatchID : Number  // the ID for this instrument, as defined by
-                                  // the MIDI spec
-			instrumentFamilyID : Number // the ID for this instrument's family, as
-                                  // defined by the MIDI spec
-		}
-	]
+  // the transport and timing data
+  header: {
+    bpm: Number,                      // the tempo, e.g. 120
+    timeSignature: [Number, Number],  // the time signature, e.g. [4, 4],
+    PPQ: Number                       // the Pulses Per Quarter of the midi file
+  },
+
+  // an array of midi tracks
+  tracks: [
+    {
+      name: String,                   // the track name if one was given
+      notes: [
+        {
+          midi: Number,               // midi number, e.g. 60
+          time: Number,               // time in seconds
+          note: String,               // note name, e.g. "C4"
+          velocity: Number,           // normalized 0-1 velocity
+          duration: String,           // duration between noteOn and noteOff
+        }
+      ],
+
+      // midi control changes
+      controlChanges: {
+        // if there are control changes in the midi file
+        '91': [
+          {
+            number: Number,           // the cc number
+            time: Number,             // time in seconds
+            value: Number,            // normalized 0-1
+          }
+        ],
+      },
+
+      instrumentNumber: Number,       // the ID for this instrument, as defined
+                                      // by the MIDI spec
+      instrumentFamily: String,       // the name of this instrument's family,
+                                      // as defined by the MIDI spec
+      instrument: String,             // the instrument name, as defined by the
+                                      // MIDI spec
+    }
+  ]
 }
 ```
 
@@ -66,10 +70,10 @@ The data parsed from the midi file looks like this:
 If you are using Node.js or have the raw binary string from the midi file, just use the `parse` method:
 
 ```javascript
-fs.readFile("test.mid", "binary", function(err, midiBlob){
-	if (!err){
-		var midi = MidiConvert.parse(midiBlob)
-	}
+fs.readFile("test.mid", "binary", function(err, midiBlob) {
+  if (!err) {
+    var midi = MidiConvert.parse(midiBlob)
+  }
 })
 ```
 
@@ -78,18 +82,18 @@ fs.readFile("test.mid", "binary", function(err, midiBlob){
 You can also create midi files from scratch of by modifying an existing file.
 
 ```javascript
-//create a new midi file
+// create a new midi file
 var midi = MidiConvert.create()
-//add a track
+// add a track
 midi.track()
-  //select an instrument type
+  // select an instrument by its MIDI patch number
   .patch(32)
-	//chain note events: note, time, duration
-	.note(60, 0, 2)
-	.note(63, 1, 2)
-	.note(60, 2, 2)
+  // chain note events: note, time, duration
+  .note(60, 0, 2)
+  .note(63, 1, 2)
+  .note(60, 2, 2)
 
-//write the output
+// write the output
 fs.writeFileSync("output.mid", midi.encode(), "binary")
 ```
 
@@ -100,21 +104,21 @@ The note data can be easily passed into [Tone.Part](http://tonejs.github.io/docs
 ```javascript
 var synth = new Tone.PolySynth(8).toMaster()
 
-MidiConvert.load("path/to/midi.mid", function(midi){
+MidiConvert.load("path/to/midi.mid", function(midi) {
 
-	//make sure you set the tempo before you schedule the events
-	Tone.Transport.bpm.value = midi.bpm
+  // make sure you set the tempo before you schedule the events
+  Tone.Transport.bpm.value = midi.header.bpm
 
-	//pass in the note events from one of the tracks as the second argument to Tone.Part
-	var midiPart = new Tone.Part(function(time, note){
+  // pass in the note events from one of the tracks as the second argument to
+  // Tone.Part var midiPart = new Tone.Part(function(time, note) {
 
-		//use the events to play the synth
-		synth.triggerAttackRelease(note.name, note.duration, time, note.velocity)
+    //use the events to play the synth
+    synth.triggerAttackRelease(note.name, note.duration, time, note.velocity)
 
-	}, midi.tracks[0].notes).start()
+  }, midi.tracks[0].notes).start()
 
-	//start the transport to hear the events
-	Tone.Transport.start()
+  // start the transport to hear the events
+  Tone.Transport.start()
 })
 ```
 

--- a/src/Midi.js
+++ b/src/Midi.js
@@ -64,9 +64,10 @@ class Midi {
 		//replace the previous tracks
 		this.tracks = []
 
-		midiData.tracks.forEach((trackData) => {
+		midiData.tracks.forEach((trackData, i) => {
 
 			const track = new Track()
+			track.id = i
 			this.tracks.push(track)
 
 			let absoluteTime = 0

--- a/src/MidiConvert.d.ts
+++ b/src/MidiConvert.d.ts
@@ -12,16 +12,15 @@ export interface Track {
   instrumentNumber: number,
   instrumentFamily: string,
   notes: Array<Note>,
+  startTime: number,
   duration: number,
   length: number,
 };
 
 export interface ControlChange {
-  time: number,
-  name: string,
-  midi: number,
-  velocity: number,
-  duration: number,
+  number: number,
+  time: string,
+  value: number,
 };
 
 export interface MIDI {
@@ -30,6 +29,8 @@ export interface MIDI {
     timeSignature: [number, number],
     PPQ: number,
   },
+
+  startTime: number,
   duration: number,
 
   tracks: Array<Track>,

--- a/src/MidiConvert.d.ts
+++ b/src/MidiConvert.d.ts
@@ -7,6 +7,7 @@ export interface Note {
 };
 
 export interface Track {
+  id?: number,
   name: string,
   instrument: string,
   instrumentNumber: number,


### PR DESCRIPTION
Tracks are easier to work with if they have a fixed ID.  This allows you to display tracks in a different order than they appear in the model (for instance, sorted by `instrumentFamily`), and still trace events back to the correct track.

This can be done in application code, but because it's both simple and common, I'm opening a PR upstream.

As you can see from the commit history, this depends on #19.

Closes #17