### PR TITLE
added drumKitByPatchID to exports

### DIFF
--- a/src/MidiConvert.d.ts
+++ b/src/MidiConvert.d.ts
@@ -7,7 +7,7 @@ export interface Note {
 };
 
 export interface Track {
-	id?: number,
+	id: number,
 	channelNumber: number,
 	name: string,
 	instrument: string,

--- a/src/MidiConvert.js
+++ b/src/MidiConvert.js
@@ -1,9 +1,10 @@
 import {Midi} from './Midi'
-import {instrumentByPatchID, instrumentFamilyByID} from './instrumentMaps'
+import {instrumentByPatchID, instrumentFamilyByID, drumKitByPatchID} from './instrumentMaps'
 
 const MidiConvert = {
 	instrumentByPatchID,
 	instrumentFamilyByID,
+	drumKitByPatchID,
 
 	/**
 	 *  Parse all the data from the Midi file into this format:

--- a/src/instrumentMaps.js
+++ b/src/instrumentMaps.js
@@ -149,13 +149,13 @@ export const instrumentFamilyByID = [
 ]
 
 export const drumKitByPatchID = {
-	 [0]: "standard kit",
-	 [8]: "room kit",
-	[16]: "power kit",
-	[24]: "electronic kit",
-	[25]: "tr-808 kit",
-	[32]: "jazz kit",
-	[40]: "brush kit",
-	[48]: "orchestra kit",
-	[56]: "sound fx kit",
+	 0: "standard kit",
+	 8: "room kit",
+	16: "power kit",
+	24: "electronic kit",
+	25: "tr-808 kit",
+	32: "jazz kit",
+	40: "brush kit",
+	48: "orchestra kit",
+	56: "sound fx kit",
 }


### PR DESCRIPTION
Was already in MidiConvert.d.ts, but forgot to add it to the index.