### PR TITLE
added module to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.4.1",
   "description": "Convert binary midi into Tone.js-friendly JSON",
   "main": "build/MidiConvert.js",
+  "module": "src/MidiConvert.js",
   "types": "src/MidiConvert.d.ts",
   "scripts": {
     "clean": "rm -rf ./build/*; mkdir -p ./build/",
@@ -21,9 +22,11 @@
     "url": "https://github.com/Tonejs/MidiConvert/issues"
   },
   "homepage": "https://tonejs.github.com/MidiConvert/",
-  "devDependencies": {
+  "dependencies": {
     "jsmidgen": "^0.1.5",
-    "midi-file-parser": "^1.0.0",
+    "midi-file-parser": "^1.0.0"
+  },
+  "devDependencies": {
     "babel-core": "^6.17.0",
     "babel-loader": "^6.2.5",
     "babel-preset-es2015": "^6.16.0",


### PR DESCRIPTION
This makes working on MidiConvert easier, as you don't have to build between changes.  It also enables consumers to use one build tool for all their dependencies, which should allow bundles to be more efficient (both through tree-shaking, and through eliminating repetitive polyfills for module loading).

Specified in https://github.com/dherman/defense-of-dot-js/blob/master/proposal.md