### PR TITLE
Add track name when encoding MIDI

### DIFF
--- a/src/Midi.js
+++ b/src/Midi.js
@@ -145,6 +145,17 @@ class Midi {
 		this.tracks.forEach((track) => {
 			const trackEncoder = output.addTrack()
 			trackEncoder.setTempo(this.bpm)
+
+			if (track.name) {
+				trackEncoder.addEvent(
+					new Encoder.MetaEvent({
+						time: 0,
+						type: Encoder.MetaEvent.TRACK_NAME,
+						data: track.name
+					})
+				)
+			}
+
 			track.encode(trackEncoder, this.header)
 		})
 		return output.toBytes()


### PR DESCRIPTION
Each MIDI tack can have its own name, the change in this PR encodes the tack name if `Track.name` is present.