### PR TITLE
fixed CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "babel-core": "^6.17.0",
     "babel-loader": "7",
-    "babel-preset-es2015": "7",
+    "babel-preset-es2015": "6.24.1",
     "chai": "^3.3.0",
     "codecov": "^1.0.1",
     "jsmidgen": "^0.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -489,7 +489,7 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-preset-es2015@7:
+babel-preset-es2015@6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz#d44050d6bc2c9feea702aaf38d727a0210538939"
   dependencies:


### PR DESCRIPTION
Looks like there isn't a babel-preset-es2015@7 yet.