### PR TITLE
Unhandled Promise [depricated] fix

### DIFF
--- a/src/Midi.js
+++ b/src/Midi.js
@@ -60,7 +60,9 @@ class Midi {
 			})
 			request.addEventListener('error', fail)
 			request.send(data)
-		})
+		}).catch(function(error) {
+				console.log(error);
+			});
 	}
 
 	/**


### PR DESCRIPTION
fairly simple but came across this error and it will crash node servers soon

> (node:91812) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.