### PR TITLE
Update input type for parse

### DIFF
--- a/src/MidiConvert.d.ts
+++ b/src/MidiConvert.d.ts
@@ -47,7 +47,7 @@ export interface MIDI {
 	toJSON(): MIDI,
 }
 
-export function parse(raw: ArrayBuffer): MIDI;
+export function parse(raw: string): MIDI;
 export function load(url: string, data?: any, method?: 'GET'|'POST'): Promise<MIDI>;
 export function create(): MIDI;
 export function fromJSON(json: object): MIDI;

--- a/src/MidiConvert.d.ts
+++ b/src/MidiConvert.d.ts
@@ -47,7 +47,7 @@ export interface MIDI {
 	toJSON(): MIDI,
 }
 
-export function parse(raw: string): MIDI;
+export function parse(raw: ArrayBuffer|string): MIDI;
 export function load(url: string, data?: any, method?: 'GET'|'POST'): Promise<MIDI>;
 export function create(): MIDI;
 export function fromJSON(json: object): MIDI;


### PR DESCRIPTION
midi-file-parser expects a string as input, not an ArrayBuffer. This also matches with how the tests do readFileSync with a "binary" encoding specified, which will result in string output.