### PR TITLE
export MidiJSON from Midi.ts

### DIFF
--- a/src/Midi.ts
+++ b/src/Midi.ts
@@ -153,7 +153,7 @@ export class Midi {
 /**
  * The MIDI data in JSON format
  */
-interface MidiJSON {
+export interface MidiJSON {
 	header: HeaderJSON;
 	tracks: TrackJSON[];
 }


### PR DESCRIPTION
This adds an export for the `MidiJSON` type from `Midi.ts` -- it's helpful if the parsed JSON is exposed from an API and you are using a typed client.