### PR TITLE
Re-export TrackJSON and HeaderJSON types

### DIFF
--- a/src/Midi.ts
+++ b/src/Midi.ts
@@ -157,3 +157,6 @@ export interface MidiJSON {
 	header: HeaderJSON;
 	tracks: TrackJSON[];
 }
+
+export type TrackJSON = TrackJSON;
+export type HeaderJSON = HeaderJSON;


### PR DESCRIPTION
Building off of https://github.com/Tonejs/Midi/pull/87, this re-exports `TrackJSON` and `HeaderJSON` types.