### PR TITLE
Change the track duration counting method.

### DIFF
--- a/src/Track.ts
+++ b/src/Track.ts
@@ -156,24 +156,34 @@ export class Track {
 	 * The end time of the last event in the track
 	 */
 	get duration(): number {
-		const lastNote = this.notes[this.notes.length - 1];
-		if (lastNote) {
-			return lastNote.time + lastNote.duration;
-		} else {
+		if (!this.notes.length)
 			return 0;
+
+		let maxDuration = this.notes[this.notes.length - 1].time + this.notes[this.notes.length - 1].duration;
+		for (let i = 0; i < this.notes.length - 1; i++) {
+			let duration = this.notes[i].time + this.notes[i].duration;
+			if (maxDuration < duration)
+				maxDuration = duration;
 		}
+
+		return maxDuration;
 	}
 
 	/**
 	 * The end time of the last event in the track in ticks
 	 */
 	get durationTicks(): number {
-		const lastNote = this.notes[this.notes.length - 1];
-		if (lastNote) {
-			return lastNote.ticks + lastNote.durationTicks;
-		} else {
+		if (!this.notes.length)
 			return 0;
+
+		let maxDuration = this.notes[this.notes.length - 1].ticks + this.notes[this.notes.length - 1].durationTicks;
+		for (let i = 0; i < this.notes.length - 1; i++) {
+			let duration = this.notes[i].ticks + this.notes[i].durationTicks;
+			if (maxDuration < duration)
+				maxDuration = duration;
 		}
+
+		return maxDuration;
 	}
 
 	/**


### PR DESCRIPTION
Hi, thank you very much for your work with Midi. It helps me a lot with my thesis. But I feel like the duration of a track is a little non-intuitive. Let's say I have two notes in one track:

`{ note: 'A5', time: 0, duration: 100 }` and `{ note: 'D5', time: 1, duration: 2 }`, right now the duration of the track is 3, which doesn't feel right. So I changed it to get the 100.

Maybe I am missing something and your way is actually more useful for other examples. But I think it would be nice to have an option for getting this kind of duration.