### PR TITLE
ES Module Build

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"lint": "eslint --ext ts ./src",
 		"lint:fix": "npm run lint -- --fix",
 		"watch": "webpack -w --mode=development",
-		"test": "nyc mocha --timeout=10000 --require ts-node/register ./test/*.ts"
+		"test": "env TS_NODE_PROJECT=\"tsconfig.testing.json\" nyc mocha --timeout=10000 --require ts-node/register ./test/*.ts"
 	},
 	"files": [
 		"build",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,13 +2,14 @@
 	"compilerOptions": {
 		"noImplicitAny": false,
 		"outDir": "dist",
-		"module": "commonjs",
+		"module": "ES2015",
 		"sourceMap": true,
 		"esModuleInterop": true,
-		"target" : "es5",
+		"target" : "ES6",
 		"declaration": true,
 		// "noUnusedLocals": true,
 		"lib" : ["es2015", "es2017", "dom"],
+		"moduleResolution": "node",
 		"types": [
 			"node",
 			"mocha"

--- a/tsconfig.testing.json
+++ b/tsconfig.testing.json
@@ -1,0 +1,34 @@
+{
+	"compilerOptions": {
+		"noImplicitAny": false,
+		"outDir": "dist",
+		"module": "CommonJS",
+		"sourceMap": true,
+		"esModuleInterop": true,
+		"target" : "ES5",
+		"declaration": true,
+		// "noUnusedLocals": true,
+		"lib" : ["es2015", "es2017", "dom"],
+		"moduleResolution": "node",
+		"types": [
+			"node",
+			"mocha"
+		]
+	},
+	"files": [
+		"./src/midi-file.d.ts"
+	],
+	"include": [
+		"./src/*.ts"
+	],
+	"exclude": [
+		// "node_modules"
+	],
+	"typedocOptions": {
+		"exclude" : ["./src/Encode.ts", "./src/BinarySearch.ts", "./src/InstrumentMaps.ts"],
+		"mode": "file",
+		"excludeNotExported" : true,
+		"out": "docs",
+		"theme" : "minimal"
+    }
+}


### PR DESCRIPTION
Updated tsconfig.json to produce ES2015 modules and target ES6 same as tone.js.
This only affects those using import. The configs for the UMD version are untouched.
For issue #117 