### PR TITLE
scale control changes

### DIFF
--- a/src/Encode.ts
+++ b/src/Encode.ts
@@ -40,7 +40,7 @@ function encodeControlChange(cc: ControlChange, channel: number): MidiController
 		controllerType: cc.number,
 		deltaTime: 0,
 		type: "controller",
-		value: cc.value,
+		value: Math.floor(cc.value * 127),
 	};
 }
 

--- a/src/Track.ts
+++ b/src/Track.ts
@@ -127,8 +127,8 @@ export class Track {
 			});
 
 			const endOfTrackEvent:
-				| MidiEndOfTrackEvent
-				| undefined = trackData.find(
+			| MidiEndOfTrackEvent
+			| undefined = trackData.find(
 				(event): event is MidiEndOfTrackEvent =>
 					event.type === "endOfTrack"
 			);
@@ -169,8 +169,8 @@ export class Track {
 	 */
 	addCC(
 		props:
-			| Omit<ControlChangeInterface, "ticks">
-			| Omit<ControlChangeInterface, "time">
+		| Omit<ControlChangeInterface, "ticks">
+		| Omit<ControlChangeInterface, "time">
 	): this {
 		const header = privateHeaderMap.get(this);
 		const cc = new ControlChange(
@@ -193,8 +193,8 @@ export class Track {
 	 */
 	addPitchBend(
 		props:
-			| Omit<PitchBendInterface, "ticks">
-			| Omit<PitchBendInterface, "time">
+		| Omit<PitchBendInterface, "ticks">
+		| Omit<PitchBendInterface, "time">
 	): this {
 		const header = privateHeaderMap.get(this);
 		const pb = new PitchBend({}, header);


### PR DESCRIPTION
Control changes are scaled from 0 to 1 rather than 0 to 127. This makes encoded MIDI files silent since control change 7 (volume) will be almost 0. This commit scales the control change values from 0 to 127 in the same way note velocities are scaled. This addresses issues #127 and #129 