### PR TITLE
Temporary fix to conflicting types with midi-file

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
 	},
 	"dependencies": {
 		"array-flatten": "^2.1.2",
-		"midi-file": "^1.1.2"
+		"midi-file": "1.1.2"
 	},
 	"nyc": {
 		"include": [


### PR DESCRIPTION
Leaving `midi-file` to version 1.1.2 and don't update to 1.2.0 could be a temporary fix to conflicting types.