### PR TITLE
Applying pitch bends as part of fromJSON

### DIFF
--- a/src/Track.ts
+++ b/src/Track.ts
@@ -291,6 +291,13 @@ export class Track {
 				velocity: n.velocity,
 			});
 		});
+		json.pitchBends.forEach((pb) => {
+			this.addPitchBend({
+				value: pb.value,
+				ticks: pb.value,
+				time: pb.time
+			});
+		});
 	}
 
 	/**


### PR DESCRIPTION
Thanks so much for writing this wrapper over `midi-file`, it's been really useful in my project - `midi-to-lsdj`. 

I noticed that when calling `fromJSON` (which I use a lot to set up a test MIDI objects) that pitch bends weren't being applied if they were part of that JSON representation.

I've added this to the `fromJSON` method in `Track` but I wasn't sure if I should add a pitch bend event to the `bach_846.json` file used in the tests or not to verify the behaviour.